### PR TITLE
Fix broken url in editors.md

### DIFF
--- a/docs/integrations/editors.md
+++ b/docs/integrations/editors.md
@@ -288,7 +288,7 @@ $ git checkout origin/stable -b stable
 ##### Arch Linux
 
 On Arch Linux, the plugin is shipped with the
-[`python-black`](https://archlinux.org/packages/community/any/python-black/) package, so
+[`python-black`](https://archlinux.org/packages/extra/any/python-black/) package, so
 you can start using it in Vim after install with no additional setup.
 
 ##### Vim 8 Native Plugin Management


### PR DESCRIPTION
Earlier this year, Arch Linux changed the structure of their repos as announced in [this post](https://archlinux.org/news/git-migration-announcement/). This PR updates the link in editors.md that points to an Arch Linux package to point to the package's new location. 

I do not know if this warrants a changelog entry.

- [ ] Add an entry in `CHANGES.md` if necessary?
- [ X ] Add / update tests if necessary?
- [ X ] Add new / update outdated documentation?
